### PR TITLE
Field improvements

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -21,3 +21,4 @@ Codem\DamnFineUploader\EditableUploadField:
   # turn this off once migration has run
   run_migration_1: true
   run_migration_manymanyhasmany: false
+  run_migration_allowedmimetypedeprecation: true

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -18,7 +18,7 @@ Codem\DamnFineUploader\DamnFineUploaderField:
       forceConfirm: true
       method: 'POST'
 Codem\DamnFineUploader\EditableUploadField:
-  # turn this off once migration has run
-  run_migration_1: true
+  # migration_1 is fineuploader deprecation
+  run_migration_1: false
   run_migration_manymanyhasmany: false
-  run_migration_allowedmimetypedeprecation: true
+  run_migration_allowedmimetypedeprecation: false

--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -4,3 +4,6 @@ Name: dfu_extensions
 SilverStripe\Assets\File:
   extensions:
     - 'Codem\DamnFineUploader\FileExtension'
+SilverStripe\SiteConfig\SiteConfig:
+  extensions:
+    - 'Codem\DamnFineUploader\SiteConfigExtension'

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require": {
         "php": "^7.1",
         "silverstripe/userforms": "^5.6",
-        "silverstripe/mimevalidator": "^2"
+        "silverstripe/mimevalidator": "^2",
+        "symbiote/silverstripe-multivaluefield": "^5"
     },
     "suggest" : {
         "dnadesign/silverstripe-elemental-userforms" : "Provides form content blocks as part of elemental"

--- a/src/Controllers/UploadPageController.php
+++ b/src/Controllers/UploadPageController.php
@@ -78,10 +78,8 @@ class UploadPageController extends \PageController
             $field->setUseDateFolder($data->UseDateFolder == 1);
         }
 
-        $types = trim($data->AllowedMimeTypes);
-        if ($types) {
-            $pattern = '/\s{1,}/';
-            $types = preg_split($pattern, $types);
+        $types = $data->getAllowedMimeTypes();
+        if (!empty($types)) {
             $field->setAcceptedTypes($types);
         }
 

--- a/src/Extensions/SiteConfigExtension.php
+++ b/src/Extensions/SiteConfigExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Codem\DamnFineUploader;
+
+use SilverStripe\Assets\File;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Forms\FieldList;
+use Silverstripe\ORM\DataExtension;
+use Symbiote\MultiValueField\Fields\MultiValueCheckboxField;
+use Symbiote\MultiValueField\Fields\MultiValueDropdownField;
+use Symbiote\MultiValueField\Fields\MultiValueListField;
+use Symbiote\MultiValueField\ORM\FieldType\MultiValueField;
+
+class SiteConfigExtension extends DataExtension {
+
+    private static $db = [
+        'AllowedFileExtensions' => MultiValueField::class
+    ];
+
+    /**
+     * Get the allowed file extensions for this site
+     */
+    protected function getAllowedFileTypes() {
+        $allowed_extensions = File::getAllowedExtensions();
+        if(!is_array($allowed_extensions)) {
+            return [];
+        } else {
+            $exts = array_filter($allowed_extensions);
+            $data = [];
+            foreach($exts as $ext) {
+                $data[$ext] = $ext;
+            }
+            return $data;
+        }
+    }
+
+    public function updateCMSFields(FieldList $fields)
+    {
+        $owner = $this->owner;
+        $fields->addFieldToTab(
+            'Root.Uploads',
+            MultiValueListField::create(
+                'AllowedFileExtensions',
+                _t(
+                    'DamnFineUploader.SELECT_ALLOWED_TYPES',
+                    'Select allowed file types for uploads to this website'
+                ),
+                $this->getAllowedFileTypes()
+            )
+        );
+        return $fields;
+    }
+
+}

--- a/src/Fields/DamnFineUploaderField.php
+++ b/src/Fields/DamnFineUploaderField.php
@@ -808,6 +808,7 @@ abstract class DamnFineUploaderField extends FormField implements FileHandleFiel
     /**
      * Return a list of extensions matching the file types provided
      * @param array $types e.g  ['image/jpg', 'image/gif']
+     * @return array
      */
     final public function getExtensionsForTypes(array $types)
     {

--- a/src/Fields/DamnFineUploaderField.php
+++ b/src/Fields/DamnFineUploaderField.php
@@ -696,7 +696,7 @@ abstract class DamnFineUploaderField extends FormField implements FileHandleFiel
             // returns values in $types that are not in the list of denied types
             $types = array_diff($types, $denied);
         }
-        return $types;
+        return array_filter($types);
     }
 
     /**
@@ -723,7 +723,7 @@ abstract class DamnFineUploaderField extends FormField implements FileHandleFiel
     public function getAcceptedTypes()
     {
         $mimetypes = $this->lib_config['validation']['acceptFiles'];
-        if (is_string($mimetypes) && strpos($mimetypes, ",") !== false) {
+        if (is_string($mimetypes)) {
             // configuration is provided as a string
             $mimetypes = explode(",", $mimetypes);
             // @var array

--- a/src/Fields/TypeSelectionField.php
+++ b/src/Fields/TypeSelectionField.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Codem\DamnFineUploader;
+
+use Silverstripe\Forms\CheckboxsetField;
+use SilverStripe\SiteConfig\SiteConfig;
+
+/**
+ * Provide a field to allow file type selections
+ */
+class TypeSelectionField extends CheckboxsetField
+{
+    public function __construct($name, $title = null, $source = [], $value = null)
+    {
+        $source = $this->getAllowedTypes();
+        parent::__construct($name, $title, $source, $value);
+    }
+
+    /**
+     * Get the allowed types from Site Config
+     */
+    public function getAllowedTypes() {
+        $config = SiteConfig::current_site_config();
+        $data = [];
+        if($config->AllowedFileExtensions) {
+            $types = $config->AllowedFileExtensions->getValues();
+            foreach($types as $type) {
+                $data[$type] = $type;
+            }
+        }
+        return $data;
+    }
+}

--- a/src/Models/EditableFormField/EditableUploadField.php
+++ b/src/Models/EditableFormField/EditableUploadField.php
@@ -4,6 +4,7 @@ namespace Codem\DamnFineUploader;
 
 use SilverStripe\UserForms\Model\EditableFormField\EditableFileField;
 use SilverStripe\Forms\HeaderField;
+use Symbiote\MultiValueField\ORM\FieldType\MultiValueField;
 
 /**
  * @note provides an EditableUploadField for the userforms module
@@ -24,7 +25,7 @@ class EditableUploadField extends EditableFileField
     private static $run_migration_manymanyhasmany = false;
 
     private static $db = [
-        'AllowedMimeTypes' => 'Text',
+        'SelectedFileTypes' => 'Text',
         'FileUploadLimit' => 'Int',
         'UseDateFolder' => 'Boolean',
         'Implementation' => 'Varchar(16)'
@@ -61,6 +62,9 @@ class EditableUploadField extends EditableFileField
             }
             if ($this->config()->get('run_migration_manymanyhasmany')) {
                 $this->migrationManyManyHasMany();
+            }
+            if ($this->config()->get('run_migration_allowedmimetypedeprecation')) {
+                $this->migrateAllowedMimeTypes();
             }
         }
     }

--- a/src/Models/EditableFormField/EditableUploadField.php
+++ b/src/Models/EditableFormField/EditableUploadField.php
@@ -23,6 +23,7 @@ class EditableUploadField extends EditableFileField
 
     private static $run_migration_1 = true;
     private static $run_migration_manymanyhasmany = false;
+    private static $run_migration_allowedmimetypedeprecation = false;
 
     private static $db = [
         'SelectedFileTypes' => 'Text',

--- a/src/Pages/UploadPage.php
+++ b/src/Pages/UploadPage.php
@@ -20,6 +20,7 @@ use SilverStripe\UserForms\Model\EditableFormField\EditableFileField;
 use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Member;
+use Symbiote\MultiValueField\ORM\FieldType\MultiValueField;
 
 /**
  * A page that handles file uploads
@@ -32,7 +33,7 @@ class UploadPage extends \Page implements PermissionProvider
 
     private static $db = [
         'MaxFileSizeMB' => 'Float',
-        'AllowedMimeTypes' => 'Text',
+        'SelectedFileTypes' => 'Text',
         'FileUploadLimit' => 'Int',
         'UseDateFolder' => 'Boolean',
         'FormFieldTitle' => 'Varchar(255)',

--- a/src/Traits/CMSFieldConfigurator.php
+++ b/src/Traits/CMSFieldConfigurator.php
@@ -2,15 +2,17 @@
 
 namespace Codem\DamnFineUploader;
 
+use SilverStripe\Assets\File;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Control\HTTP;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\HeaderField;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\Assets\File;
-use SilverStripe\Assets\Folder;
-use SilverStripe\Core\Config\Config;
+use SilverStripe\MimeValidator\MimeUploadValidator;
 
 /**
  * Trait for editable DFU field implementations
@@ -30,6 +32,50 @@ trait CMSFieldConfigurator
     public function getPHPMaxFileSizeMB()
     {
         return round(static::get_php_max_file_size() / 1024 / 1024, 1);
+    }
+
+    /**
+     * Get the allowed mime types, based on the selected file types
+     * @return array
+     */
+    public function getAllowedMimeTypes() {
+        $selected = $this->SelectedFileTypes;
+        $mimetypes = [];
+        $types = json_decode($selected, true);
+        if(json_last_error() == JSON_ERROR_NONE && is_array($types)) {
+            foreach($types as $type) {
+                $expected = $this->getMimeTypes($type);
+                $mimetypes = array_merge($mimetypes, $expected);
+            }
+        }
+        return array_unique($mimetypes);
+    }
+
+    /**
+     * This is pinched from MimeUploadValidator
+     * @return array
+     */
+    public function getMimeTypes($extension) {
+        $expectedMimes = [];
+        // Get the mime types set in framework core
+        $knownMimes = Config::inst()->get(HTTP::class, 'MimeTypes');
+        if (isset($knownMimes[$extension])) {
+            $expectedMimes[] = $knownMimes[$extension];
+        }
+
+        // Get the mime types and their variations from mime validator
+        $knownMimes =  Config::inst()->get(MimeUploadValidator::class, 'MimeTypes');
+        if (isset($knownMimes[$extension])) {
+            $mimes = (array) $knownMimes[$extension];
+
+            foreach ($mimes as $mime) {
+                if (!in_array($mime, $expectedMimes)) {
+                    $expectedMimes[] = $mime;
+                }
+            }
+        }
+
+        return $expectedMimes;
     }
 
     /**
@@ -61,17 +107,34 @@ trait CMSFieldConfigurator
                 ->setTitle('Maximum number of files allowed in the upload')
         );
 
-        // Get the configured values for the field
-        $config = Config::inst()->get(DamnFineUploaderField::class, 'implementation');
-        $defaults = "";
-        if (!empty($config['validation']['acceptFiles'])) {
-            $defaults = strip_tags($config['validation']['acceptFiles']);
+        // get allowed types field
+
+        $mimetypes = $this->getAllowedMimeTypes();
+        $type_description = trim(implode(", ", $mimetypes));
+        if(!$type_description) {
+            $type_description = _t(
+                'DamnFineUploader.NONE',
+                '(none)'
+            );
         }
         $fields->addFieldToTab(
             'Root.' . $tab,
-            TextareaField::create('AllowedMimeTypes')
-                ->setTitle(_t('DamnFineUploader.ACCEPTED_MIMETYPES', 'Accepted mime types allowed for uploads made via this field (one per line)'))
-                ->setDescription(sprintf(_t('DamnFineUploader.DEFAULT_MIMETYPES', 'Default if none set: %s'), $defaults))
+            TypeSelectionField::create('SelectedFileTypes')
+                ->setTitle(
+                    _t(
+                        'DamnFineUploader.SELECT_FILE_TYPES',
+                        'Select allowed file types for this form'
+                    )
+                )
+                ->setDescription(
+                    _t(
+                        'DamnFineUploader.ALLOWED_MIME_TYPES',
+                        "The following mimetypes are allowed, based on this selection: <strong>{types}</strong>",
+                        [
+                            'types' => $type_description
+                        ]
+                    )
+                )
         );
 
         $fields->addFieldToTab(

--- a/src/Traits/CMSFieldConfigurator.php
+++ b/src/Traits/CMSFieldConfigurator.php
@@ -123,7 +123,7 @@ trait CMSFieldConfigurator
                 ->setTitle(
                     _t(
                         'DamnFineUploader.SELECT_FILE_TYPES',
-                        'Select allowed file types for this form'
+                        'Select allowed file types for this upload field'
                     )
                 )
                 ->setDescription(

--- a/src/Traits/EditableDamnFineUploader.php
+++ b/src/Traits/EditableDamnFineUploader.php
@@ -168,10 +168,8 @@ trait EditableDamnFineUploader
 
         // Apply configurable settings
         // set accepted types on the field e.g image/jpeg
-        $types = trim($this->AllowedMimeTypes);
-        if ($types) {
-            $pattern = '/\s{1,}/';
-            $types = preg_split($pattern, $types);
+        $types = $this->getAllowedMimeTypes();
+        if (!empty($types)) {
             $field->setAcceptedTypes($types);
         }
 

--- a/src/Traits/Migrations.php
+++ b/src/Traits/Migrations.php
@@ -5,6 +5,7 @@ namespace Codem\DamnFineUploader;
 use SilverStripe\Assets\File;
 use SilverStripe\Core\Convert;
 use SilverStripe\ORM\DB;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 
 /**
@@ -89,7 +90,7 @@ trait Migrations
     */
     protected function migrateAllowedMimeTypes() {
 
-        $process_list = function($list, $table) {
+        $process_list = function($list, $table, $class) {
             if(!$list) {
                 DB::alteration_message("List is not a valid result set", "error");
             }
@@ -101,12 +102,22 @@ trait Migrations
                     $types = preg_split($pattern, $record['AllowedMimeTypes']);
                     $exts = $field->getExtensionsForTypes($types);
                     DB::alteration_message("Migrating #{$record['ID']} AllowedMimeTypes to  SelectedFileTypes", "changed");
-                    $new = json_encode($exts);
-                    $sql = "UPDATE `" . Convert::raw2sql($table) . "` SET AllowedMimeTypes = NULL, SelectedFileTypes = '" . Convert::raw2sql($new) . "' WHERE ID = {$record['ID']}";
-                    DB::alteration_message("Runnign sql {$sql}", "changed");
+                    $serialised = json_encode($exts);
+                    $sql = "UPDATE `" . Convert::raw2sql($table) . "`"
+                            . " SET AllowedMimeTypes = NULL, "// deprecated field
+                            . " SelectedFileTypes = '" . Convert::raw2sql($serialised) . "'"
+                            . " WHERE ID = {$record['ID']}";
+                    DB::alteration_message("Updating {$class} record #{$record['ID']}", "changed");
                     DB::query($sql);
+                    $instance = DataObject::get($class)->byId($record['ID']);
+                    if($instance) {
+                        // update the record via ORM and write to stage (do not publish)
+                        $instance->SelectedFileTypes = $serialised;
+                        $instance->writeToStage(Versioned::DRAFT);
+                    }
+                    DB::alteration_message("Updated {$class} record #{$record['ID']}", "changed");
                 } else {
-                    DB::alteration_message("Ignoring #{$record['ID']} AllowedMimeTypes to SelectedFileTypes, possibly already migrated", "info");
+                    DB::alteration_message("Ignoring {$class} record #{$record['ID']} AllowedMimeTypes to SelectedFileTypes, possibly already migrated", "info");
                 }
             }
         };
@@ -114,7 +125,7 @@ trait Migrations
         try {
             $list = DB::query("SELECT ID, AllowedMimeTypes, SelectedFileTypes FROM EditableUploadField");
             DB::alteration_message("Attempting to migrate EditableUploadField records", "changed");
-            $process_list($list, "EditableUploadField");
+            $process_list($list, "EditableUploadField", EditableUploadField::class);
         } catch (\Exception $e) {
             DB::alteration_message("EditableUploadField migration failed ({$e->getMessage()}) - if this has completed, set run_migration_allowedmimetypedeprecation:false in config", "error");
         }
@@ -122,7 +133,7 @@ trait Migrations
         try {
             $list = DB::query("SELECT ID, AllowedMimeTypes, SelectedFileTypes FROM DamnFineUploaderPage");
             DB::alteration_message("Attempting to migrate DamnFineUploaderPage records", "changed");
-            $process_list($list, "DamnFineUploaderPage");
+            $process_list($list, "DamnFineUploaderPage", UploadPage::class);
         } catch (\Exception $e) {
             DB::alteration_message("DamnFineUploaderPage Migration failed ({$e->getMessage()}) - if this has completed, set run_migration_allowedmimetypedeprecation:false in config", "error");
         }

--- a/src/Traits/Migrations.php
+++ b/src/Traits/Migrations.php
@@ -111,12 +111,21 @@ trait Migrations
             }
         };
 
-        $list = DB::query("SELECT ID, AllowedMimeTypes, SelectedFileTypes FROM EditableUploadField");
-        DB::alteration_message("Attempting to migrate EditableUploadField records", "changed");
-        $process_list($list, "EditableUploadField");
-        $list = DB::query("SELECT ID, AllowedMimeTypes, SelectedFileTypes FROM DamnFineUploaderPage");
-        DB::alteration_message("Attempting to migrate UploadPage records", "changed");
-        $process_list($list, "UploadPage");
+        try {
+            $list = DB::query("SELECT ID, AllowedMimeTypes, SelectedFileTypes FROM EditableUploadField");
+            DB::alteration_message("Attempting to migrate EditableUploadField records", "changed");
+            $process_list($list, "EditableUploadField");
+        } catch (\Exception $e) {
+            DB::alteration_message("EditableUploadField migration failed ({$e->getMessage()}) - if this has completed, set run_migration_allowedmimetypedeprecation:false in config", "error");
+        }
+
+        try {
+            $list = DB::query("SELECT ID, AllowedMimeTypes, SelectedFileTypes FROM DamnFineUploaderPage");
+            DB::alteration_message("Attempting to migrate DamnFineUploaderPage records", "changed");
+            $process_list($list, "DamnFineUploaderPage");
+        } catch (\Exception $e) {
+            DB::alteration_message("DamnFineUploaderPage Migration failed ({$e->getMessage()}) - if this has completed, set run_migration_allowedmimetypedeprecation:false in config", "error");
+        }
 
     }
 

--- a/tests/UserFormFieldTest.yml
+++ b/tests/UserFormFieldTest.yml
@@ -28,7 +28,7 @@ Codem\DamnFineUploader\EditableUploadField:
   upload-field-1:
     Name: 'upload_field_name'
     Title: 'Upload field title'
-    AllowedMimeTypes: "image/jpg\nimage/jpeg\nimage/png\nimage/webp"
+    SelectedFileTypes: '["gif","jpeg","jpg","webp"]'
     MaxFileSizeMB: 10
     UseDateFolder: 1
     FileUploadLimit: 3


### PR DESCRIPTION
## Changes

> This PR provides enhancements to the field configuration experience

+ Feature: Provide a nicer method for content editors to select file types for upload (2bb5d90)
+ Feature: Provide a Settings tab where administrators can restrict upload types for a site (2bb5d90)
+ Feature: Deprecate AllowedMimeTypes, use new SelectedFileTypes (CheckboxsetField) and provide a migration path for this
+ Update tests to suit